### PR TITLE
Clarify that Node.js v18.0 does not require --experimental-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Node.js `>=17.5` and `<18.0` requires the `--experimental-fetch` node options:
 ```bash
 NODE_OPTIONS=--experimental-fetch spago run
 ```
-Node.js `>18.0` you don't need to set the `--experimental-fetch` node option.
+Node.js `>=18.0` you don't need to set the `--experimental-fetch` node option.
 
 Perform a simple `GET` request:
 ```purescript


### PR DESCRIPTION
The README says 

"Note: Node.js `<17.5` is not supported. Node.js `>=17.5` and `<18.0` requires the `--experimental-fetch` node options:" and "Node.js `>18.0` you don't need to set the `--experimental-fetch` node option."

This is ambiguous if the Node.js version is exactly 18.0, so this PR simply updates `>18.0` to `>=18.0`.