### PR TITLE
Update for js-promise migration

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,8 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "20"
+
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
         with:
@@ -29,6 +30,7 @@ jobs:
           path: |
             .spago
             output
+
       - name: Install dependencies
         run: spago install
 
@@ -36,7 +38,7 @@ jobs:
         run: spago build --no-install --purs-args '--censor-lib --strict'
 
       - name: Run tests
-        run: NODE_OPTIONS=--experimental-fetch spago -x test.dhall test
+        run: spago -x test.dhall test
 
       - name: Check formatting
         run: purs-tidy check src test

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "purescript-aff": "^v7.0.0",
     "purescript-arraybuffer-types": "^v3.0.2",
     "purescript-effect": "^v4.0.0",
-    "purescript-fetch-core": "https://github.com/rowtype-yoga/purescript-fetch-core.git#^5.0.0",
+    "purescript-fetch-core": "https://github.com/rowtype-yoga/purescript-fetch-core.git#^5.1.0",
     "purescript-foreign": "^v7.0.0",
     "purescript-http-methods": "^v6.0.0",
     "purescript-js-promise-aff": "https://github.com/purescript-contrib/purescript-js-promise-aff.git#^v1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "purescript-aff": "^v7.0.0",
     "purescript-arraybuffer-types": "^v3.0.2",
     "purescript-effect": "^v4.0.0",
-    "purescript-fetch-core": "https://github.com/thomashoneyman/purescript-fetch-core.git#main",
+    "purescript-fetch-core": "https://github.com/rowtype-yoga/purescript-fetch-core.git#^5.0.0",
     "purescript-foreign": "^v7.0.0",
     "purescript-http-methods": "^v6.0.0",
     "purescript-js-promise-aff": "https://github.com/purescript-contrib/purescript-js-promise-aff.git#^v1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,33 +1,24 @@
 {
-    "name": "purescript-fetch",
-    "license": [
-        "MIT"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/rowtype-yoga/purescript-fetch.git"
-    },
-    "ignore": [
-        "**/.*",
-        "node_modules",
-        "bower_components",
-        "output"
-    ],
-    "dependencies": {
-        "purescript-aff": "^v7.0.0",
-        "purescript-aff-promise": "^v4.0.0",
-        "purescript-arraybuffer-types": "^v3.0.2",
-        "purescript-effect": "^v4.0.0",
-        "purescript-fetch-core": "https://github.com/rowtype-yoga/purescript-fetch-core.git#v4.0.4",
-        "purescript-foreign": "^v7.0.0",
-        "purescript-http-methods": "^v6.0.0",
-        "purescript-newtype": "^v5.0.0",
-        "purescript-prelude": "^v6.0.0",
-        "purescript-record": "^v4.0.0",
-        "purescript-typelevel-prelude": "^v7.0.0",
-        "purescript-unsafe-coerce": "^v6.0.0",
-        "purescript-web-file": "^v4.0.0",
-        "purescript-web-promise": "https://github.com/purescript-web/purescript-web-promise.git#v3.0.0",
-        "purescript-web-streams": "https://github.com/purescript-web/purescript-web-streams.git#v3.0.0"
-    }
+  "name": "purescript-fetch",
+  "license": ["MIT"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rowtype-yoga/purescript-fetch.git"
+  },
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
+  "dependencies": {
+    "purescript-aff": "^v7.0.0",
+    "purescript-arraybuffer-types": "^v3.0.2",
+    "purescript-effect": "^v4.0.0",
+    "purescript-fetch-core": "https://github.com/thomashoneyman/purescript-fetch-core.git#main",
+    "purescript-foreign": "^v7.0.0",
+    "purescript-http-methods": "^v6.0.0",
+    "purescript-js-promise-aff": "https://github.com/purescript-contrib/purescript-js-promise-aff.git#^v1.0.0",
+    "purescript-newtype": "^v5.0.0",
+    "purescript-prelude": "^v6.0.0",
+    "purescript-record": "^v4.0.0",
+    "purescript-typelevel-prelude": "^v7.0.0",
+    "purescript-web-file": "^v4.0.0",
+    "purescript-web-streams": "https://github.com/purescript-web/purescript-web-streams.git#^v4.0.0"
+  }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,29 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.10-20230803/packages.dhall
-        sha256:7da82e40277c398fd70f16af6450fb74287a88e2a3c8885c065dcdb9df893761
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.10-20230806/packages.dhall
+        sha256:0c2cf73e053ddace5094ba6c0ef3077f98b7ce76b822a51af66b6bba30cddaf5
 
 in  upstream
-  with fetch-core =
-    { dependencies =
-        [ "arraybuffer-types"
-        , "arrays"
-        , "effect"
-        , "foldable-traversable"
-        , "foreign"
-        , "foreign-object"
-        , "functions"
-        , "http-methods"
-        , "js-promise"
-        , "maybe"
-        , "newtype"
-        , "prelude"
-        , "record"
-        , "tuples"
-        , "typelevel-prelude"
-        , "unfoldable"
-        , "web-file"
-        , "web-streams"
-        ]
-    , version = "main"
-    , repo = "https://github.com/thomashoneyman/purescript-fetch-core.git"
-    }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,33 +1,29 @@
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220816/packages.dhall
-        sha256:8b4467b4b5041914f9b765779c8936d6d4c230b1f60eb64f6269c71812fd7e98
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.10-20230803/packages.dhall
+        sha256:7da82e40277c398fd70f16af6450fb74287a88e2a3c8885c065dcdb9df893761
 
 in  upstream
-  with fetch-core = {
-    dependencies = [
-      "arraybuffer-types"
-    , "arrays"
-    , "console"
-    , "effect"
-    , "foldable-traversable"
-    , "foreign"
-    , "foreign-object"
-    , "functions"
-    , "http-methods"
-    , "maybe"
-    , "newtype"
-    , "nullable"
-    , "prelude"
-    , "record"
-    , "tuples"
-    , "typelevel-prelude"
-    , "unfoldable"
-    , "unsafe-coerce"
-    , "web-file"
-    , "web-promise"
-    , "web-streams"
-    ],
-    version = "v4.0.4",
-    repo = "https://github.com/rowtype-yoga/purescript-fetch-core.git"
-  } 
+  with fetch-core =
+    { dependencies =
+        [ "arraybuffer-types"
+        , "arrays"
+        , "effect"
+        , "foldable-traversable"
+        , "foreign"
+        , "foreign-object"
+        , "functions"
+        , "http-methods"
+        , "js-promise"
+        , "maybe"
+        , "newtype"
+        , "prelude"
+        , "record"
+        , "tuples"
+        , "typelevel-prelude"
+        , "unfoldable"
+        , "web-file"
+        , "web-streams"
+        ]
+    , version = "main"
+    , repo = "https://github.com/thomashoneyman/purescript-fetch-core.git"
+    }

--- a/packages.dhall
+++ b/packages.dhall
@@ -3,3 +3,5 @@ let upstream =
         sha256:0c2cf73e053ddace5094ba6c0ef3077f98b7ce76b822a51af66b6bba30cddaf5
 
 in  upstream
+  with
+    fetch-core.version = "v5.1.0"

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,13 +1,13 @@
 { name = "fetch"
 , dependencies =
   [ "aff"
-  , "aff-promise"
   , "arraybuffer-types"
   , "bifunctors"
   , "effect"
   , "fetch-core"
   , "foreign"
   , "http-methods"
+  , "js-promise-aff"
   , "maybe"
   , "newtype"
   , "ordered-collections"
@@ -15,9 +15,7 @@
   , "record"
   , "strings"
   , "typelevel-prelude"
-  , "unsafe-coerce"
   , "web-file"
-  , "web-promise"
   , "web-streams"
   ]
 , packages = ./packages.dhall

--- a/src/Fetch.purs
+++ b/src/Fetch.purs
@@ -15,7 +15,6 @@ module Fetch
 
 import Prelude
 
-import Control.Promise as Promise
 import Data.HTTP.Method (Method(..))
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
@@ -26,20 +25,21 @@ import Fetch.Core.Request as CoreRequest
 import Fetch.Core.RequestCache (RequestCache(..))
 import Fetch.Core.RequestCredentials (RequestCredentials(Omit, Include))
 import Fetch.Core.RequestMode (RequestMode(Cors, NoCors, Navigate))
+import Fetch.Internal.Headers (lookup, toHeaders, contains)
 import Fetch.Internal.Request (class ToCoreRequestOptions, class ToCoreRequestOptionsConverter, class ToCoreRequestOptionsHelper, HighlevelRequestOptions, convertHelper, convertImpl, new)
 import Fetch.Internal.Request as Request
-import Fetch.Internal.Headers (lookup, toHeaders, contains)
 import Fetch.Internal.RequestBody (class ToRequestBody, toRequestBody)
-import Fetch.Internal.Response (Response, ResponseR, arrayBuffer, blob, body, json, promiseToPromise, text)
+import Fetch.Internal.Response (Response, ResponseR, arrayBuffer, blob, body, json, text)
 import Fetch.Internal.Response as Response
 import Prim.Row (class Union)
+import Promise.Aff as Promise.Aff
 
 -- | Implementation of `fetch`, see https://developer.mozilla.org/en-US/docs/Web/API/fetch
 -- | For usage with `String` bodies. For other body types, see `fetchBody`
--- | 
+-- |
 -- | Usage:
 -- | ```purescript
--- | do 
+-- | do
 -- |   let requestUrl = "https://httpbin.org/get"
 -- |   { status, text } <- fetch requestUrl { headers: { "Accept": "application/json" }}
 -- |   responseBody <- text
@@ -66,7 +66,7 @@ fetch
   -> Aff Response
 fetch url r = do
   request <- liftEffect $ new url $ Request.convert r
-  cResponse <- Promise.toAffE $ Response.promiseToPromise <$> Core.fetch request
+  cResponse <- Promise.Aff.toAffE $ Core.fetch request
   pure $ Response.convert cResponse
 
 -- | Like `fetch`, but can accept arbitrary `RequestBody`s.
@@ -81,5 +81,5 @@ fetchBody
   -> Aff Response
 fetchBody url r = do
   request <- liftEffect $ new url $ Request.convert r
-  cResponse <- Promise.toAffE $ Response.promiseToPromise <$> Core.fetch request
+  cResponse <- Promise.Aff.toAffE $ Core.fetch request
   pure $ Response.convert cResponse

--- a/src/Fetch/Internal/Request.purs
+++ b/src/Fetch/Internal/Request.purs
@@ -16,6 +16,9 @@ import Data.Newtype (un)
 import Data.Symbol (class IsSymbol)
 import Effect (Effect)
 import Effect.Uncurried (runEffectFn2)
+import Fetch.Core.Duplex (Duplex)
+import Fetch.Core.Duplex as CoreDuplex
+import Fetch.Core.Duplex as Duplex
 import Fetch.Core.Headers (Headers)
 import Fetch.Core.Headers as CoreHeaders
 import Fetch.Core.Integrity (Integrity(..))
@@ -56,6 +59,7 @@ type HighlevelRequestOptions headers body =
   , referrer :: CoreReferrer.Referrer
   , referrerPolicy :: CoreReferrerPolicy.ReferrerPolicy
   , integrity :: CoreIntegrity.Integrity
+  , duplex :: CoreDuplex.Duplex
   )
 
 new
@@ -128,3 +132,5 @@ instance ToCoreRequestOptionsConverter "referrerPolicy" ReferrerPolicy String wh
 instance ToCoreRequestOptionsConverter "integrity" Integrity String where
   convertImpl _ = un Integrity
 
+instance ToCoreRequestOptionsConverter "duplex" Duplex String where
+  convertImpl _ = Duplex.toString

--- a/src/Fetch/Internal/Request.purs
+++ b/src/Fetch/Internal/Request.purs
@@ -17,30 +17,24 @@ import Data.Symbol (class IsSymbol)
 import Effect (Effect)
 import Effect.Uncurried (runEffectFn2)
 import Fetch.Core.Duplex (Duplex)
-import Fetch.Core.Duplex as CoreDuplex
-import Fetch.Core.Duplex as Duplex
+import Fetch.Core.Duplex as Core.Duplex
 import Fetch.Core.Headers (Headers)
-import Fetch.Core.Headers as CoreHeaders
+import Fetch.Core.Headers as Core.Headers
 import Fetch.Core.Integrity (Integrity(..))
-import Fetch.Core.Integrity as CoreIntegrity
+import Fetch.Core.Integrity as Core.Integrity
 import Fetch.Core.Referrer (Referrer)
-import Fetch.Core.Referrer as CoreReferrer
-import Fetch.Core.Referrer as Referrer
+import Fetch.Core.Referrer as Core.Referrer
 import Fetch.Core.ReferrerPolicy (ReferrerPolicy)
-import Fetch.Core.ReferrerPolicy as CoreReferrerPolicy
-import Fetch.Core.ReferrerPolicy as ReferrerPolicy
+import Fetch.Core.ReferrerPolicy as Core.ReferrerPolicy
 import Fetch.Core.Request (_unsafeNew)
-import Fetch.Core.Request as CoreRequest
+import Fetch.Core.Request as Core.Request
 import Fetch.Core.RequestBody (RequestBody)
 import Fetch.Core.RequestCache (RequestCache)
-import Fetch.Core.RequestCache as CoreRequestCache
-import Fetch.Core.RequestCache as RequestCache
+import Fetch.Core.RequestCache as Core.RequestCache
 import Fetch.Core.RequestCredentials (RequestCredentials)
-import Fetch.Core.RequestCredentials as CoreRequestCredentials
-import Fetch.Core.RequestCredentials as RequestCredentials
+import Fetch.Core.RequestCredentials as Core.RequestCredentials
 import Fetch.Core.RequestMode (RequestMode)
-import Fetch.Core.RequestMode as CoreRequestMode
-import Fetch.Core.RequestMode as RequestMode
+import Fetch.Core.RequestMode as Core.RequestMode
 import Fetch.Internal.RequestBody (class ToRequestBody, toRequestBody)
 import Prim.Row (class Lacks, class Union)
 import Prim.Row as R
@@ -53,21 +47,21 @@ type HighlevelRequestOptions headers body =
   ( method :: Method
   , headers :: { | headers }
   , body :: body
-  , credentials :: CoreRequestCredentials.RequestCredentials
-  , cache :: CoreRequestCache.RequestCache
-  , mode :: CoreRequestMode.RequestMode
-  , referrer :: CoreReferrer.Referrer
-  , referrerPolicy :: CoreReferrerPolicy.ReferrerPolicy
-  , integrity :: CoreIntegrity.Integrity
-  , duplex :: CoreDuplex.Duplex
+  , credentials :: Core.RequestCredentials.RequestCredentials
+  , cache :: Core.RequestCache.RequestCache
+  , mode :: Core.RequestMode.RequestMode
+  , referrer :: Core.Referrer.Referrer
+  , referrerPolicy :: Core.ReferrerPolicy.ReferrerPolicy
+  , integrity :: Core.Integrity.Integrity
+  , duplex :: Core.Duplex.Duplex
   )
 
 new
   :: forall input thru
-   . Union input thru CoreRequest.UnsafeRequestOptions
+   . Union input thru Core.Request.UnsafeRequestOptions
   => String
   -> { | input }
-  -> Effect CoreRequest.Request
+  -> Effect Core.Request.Request
 new url options = runEffectFn2 _unsafeNew url options
 
 class ToCoreRequestOptions input output | input -> output where
@@ -109,28 +103,28 @@ instance ToCoreRequestOptionsConverter "method" Method String where
   convertImpl _ = show
 
 instance (Homogeneous r String) => ToCoreRequestOptionsConverter "headers" { | r } Headers where
-  convertImpl _ = CoreHeaders.fromRecord
+  convertImpl _ = Core.Headers.fromRecord
 
 instance (ToRequestBody body) => ToCoreRequestOptionsConverter "body" body RequestBody where
   convertImpl _ = toRequestBody
 
 instance ToCoreRequestOptionsConverter "credentials" RequestCredentials String where
-  convertImpl _ = RequestCredentials.toString
+  convertImpl _ = Core.RequestCredentials.toString
 
 instance ToCoreRequestOptionsConverter "cache" RequestCache String where
-  convertImpl _ = RequestCache.toString
+  convertImpl _ = Core.RequestCache.toString
 
 instance ToCoreRequestOptionsConverter "mode" RequestMode String where
-  convertImpl _ = RequestMode.toString
+  convertImpl _ = Core.RequestMode.toString
 
 instance ToCoreRequestOptionsConverter "referrer" Referrer String where
-  convertImpl _ = Referrer.toString
+  convertImpl _ = Core.Referrer.toString
 
 instance ToCoreRequestOptionsConverter "referrerPolicy" ReferrerPolicy String where
-  convertImpl _ = ReferrerPolicy.toString
+  convertImpl _ = Core.ReferrerPolicy.toString
 
 instance ToCoreRequestOptionsConverter "integrity" Integrity String where
   convertImpl _ = un Integrity
 
 instance ToCoreRequestOptionsConverter "duplex" Duplex String where
-  convertImpl _ = Duplex.toString
+  convertImpl _ = Core.Duplex.toString

--- a/src/Fetch/Internal/Response.purs
+++ b/src/Fetch/Internal/Response.purs
@@ -6,14 +6,11 @@ module Fetch.Internal.Response
   , body
   , convert
   , json
-  , promiseToPromise
   , text
   ) where
 
 import Prelude
 
-import Control.Promise as Control
-import Control.Promise as Promise
 import Data.ArrayBuffer.Types (ArrayBuffer, Uint8Array)
 import Data.Map as Map
 import Data.String.CaseInsensitive (CaseInsensitiveString)
@@ -22,9 +19,8 @@ import Effect.Aff (Aff)
 import Fetch.Core.Response as CoreResponse
 import Fetch.Internal.Headers (toHeaders)
 import Foreign (Foreign)
-import Unsafe.Coerce (unsafeCoerce)
+import Promise.Aff as Promise.Aff
 import Web.File.Blob (Blob)
-import Web.Promise as Web
 import Web.Streams.ReadableStream (ReadableStream)
 
 type ResponseR =
@@ -46,22 +42,19 @@ type Response =
   }
 
 text :: CoreResponse.Response -> Aff String
-text response = CoreResponse.text response <#> promiseToPromise # Promise.toAffE
+text response = CoreResponse.text response # Promise.Aff.toAffE
 
 body :: CoreResponse.Response -> Effect (ReadableStream Uint8Array)
 body = CoreResponse.body
 
 json :: CoreResponse.Response -> Aff Foreign
-json response = CoreResponse.json response <#> promiseToPromise # Promise.toAffE
+json response = CoreResponse.json response # Promise.Aff.toAffE
 
 arrayBuffer :: CoreResponse.Response -> Aff ArrayBuffer
-arrayBuffer response = CoreResponse.arrayBuffer response <#> promiseToPromise # Promise.toAffE
+arrayBuffer response = CoreResponse.arrayBuffer response # Promise.Aff.toAffE
 
 blob :: CoreResponse.Response -> Aff Blob
-blob response = CoreResponse.blob response <#> promiseToPromise # Promise.toAffE
-
-promiseToPromise :: Web.Promise ~> Control.Promise
-promiseToPromise = unsafeCoerce
+blob response = CoreResponse.blob response # Promise.Aff.toAffE
 
 convert :: CoreResponse.Response -> Response
 convert response =

--- a/test.dhall
+++ b/test.dhall
@@ -5,17 +5,10 @@ in      conf
         , dependencies =
               conf.dependencies
             # [ "aff"
-              , "aff-promise"
-              , "console"
               , "effect"
-              , "either"
-              , "exceptions"
-              , "lists"
               , "spec"
               , "spec-discovery"
               , "strings"
-              , "transformers"
               , "debug"
-              , "media-types"
               ]
         }

--- a/test.dhall
+++ b/test.dhall
@@ -9,6 +9,5 @@ in      conf
               , "spec"
               , "spec-discovery"
               , "strings"
-              , "debug"
               ]
         }

--- a/test/Test/FetchSpec.purs
+++ b/test/Test/FetchSpec.purs
@@ -6,6 +6,7 @@ import Data.ArrayBuffer.Types (Uint8Array)
 import Data.Maybe (Maybe(..))
 import Fetch (Method(..), Referrer(..), RequestMode(..), fetch, fetchBody)
 import Fetch as Fetch
+import Fetch.Core.Duplex (Duplex(..))
 import Foreign (unsafeFromForeign)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -47,6 +48,7 @@ spec =
           , body: helloWorldStream
           , headers: { "Content-Type": "application/json" }
           , referrer: (ReferrerUrl "https://httpbin.org")
+          , duplex: Half
           }
         { json: j } <- json <#> unsafeFromForeign
         j `shouldEqual` { hello: "world" }


### PR DESCRIPTION
This updates the library to make use of `js-promise` instead of `web-promise`, including relying on a new `fetch-core` (another PR is open for that). This cannot be merged until the fetch-core PR merges, and then I can update the dependencies.